### PR TITLE
Add tooltip and updated docker images

### DIFF
--- a/app/backend/constants.js
+++ b/app/backend/constants.js
@@ -31,7 +31,7 @@ const taps = [
   {
     name: 'Salesforce',
     tapKey: 'tap-salesforce',
-    tapImage: 'gbolahan/tap-salesforce:1.0',
+    tapImage: 'dataworld/tap-salesforce:1.4.14',
     repo: 'https://github.com/singer-io/tap-salesforce',
     isLegacy: false
   }
@@ -47,7 +47,7 @@ const targets = [
   {
     name: 'Stitch',
     targetKey: 'target-stitch',
-    targetImage: 'gbolahan/target-stitch:1.0',
+    targetImage: 'dataworld/target-stitch:1.7.4',
     repo: 'https://github.com/singer-io/target-stitch'
   }
 ];

--- a/app/components/Schema/Schema.css
+++ b/app/components/Schema/Schema.css
@@ -44,5 +44,10 @@
 }
 
 .repKeyToolTip {
-  left: 12px !important;
+  left: 10px !important;
+}
+
+.infoIcon {
+  vertical-align: middle;
+  margin-left: 5px;
 }

--- a/app/components/Schema/index.js
+++ b/app/components/Schema/index.js
@@ -337,7 +337,16 @@ export default class Schema extends Component<Props, State> {
                         <tr>
                           <th className="text-center">Include</th>
                           <th>Table/Stream</th>
-                          <th id="ReplicationInfo">Replication Key</th>
+                          <th>
+                            Replication Key
+                            <i
+                              id="ReplicationInfo"
+                              className={classNames(
+                                'fa fa-info-circle',
+                                styles.infoIcon
+                              )}
+                            />
+                          </th>
                           <Tooltip
                             placement="right"
                             isOpen={this.state.tooltipOpen}


### PR DESCRIPTION
@kndungu - Updated docker images for tap-salesforce and target-stitch. Also added a tooltip to replication key selection col.

<img width="1278" alt="screenshot 2018-06-14 14 36 20" src="https://user-images.githubusercontent.com/9654881/41416771-8437f084-6fe3-11e8-924f-37773f4c1649.png">
 