### PR TITLE
Store temporary knots in a uuid folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ npm-debug.log.*
 
 # Knot temp files
 tmp
+/knots

--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,4 @@ main.js.map
 npm-debug.log.*
 
 # Knot temp files
-knot.json
-docker/tap
-docker/target
-./knots
-configs
+tmp

--- a/app/actions/knots.js
+++ b/app/actions/knots.js
@@ -46,6 +46,7 @@ export const KNOT_DELETED = 'KNOT_DELETED';
 export const FINAL_STEP = 'FINAL_STEP';
 export const LOADING_KNOT = 'LOADING_KNOT';
 export const LOADED_KNOT = 'LOADED_KNOT';
+export const LOADED_KNOT_JSON = 'LOADED_KNOT_JSON';
 export const RESET_STORE = 'RESET_STORE';
 export const RESET_KNOT_ERROR = 'RESET_KNOT_ERROR';
 export const GENERATED_UUID = 'GENERATED_UUID';
@@ -321,5 +322,28 @@ export function generateUUID() {
       type: GENERATED_UUID,
       uuid: shortid.generate()
     });
+  };
+}
+
+export function loadKnot(knot: string) {
+  return (dispatch: (action: actionType) => void) => {
+    dispatch({
+      type: LOADING_KNOT
+    });
+    return axios
+      .post(`${baseUrl}/knots/loadknot`, { knot })
+      .then((response) => {
+        dispatch({
+          type: LOADED_KNOT_JSON,
+          tap: response.data.tap,
+          target: response.data.target
+        });
+      })
+      .catch((error) => {
+        dispatch({
+          type: LOADED_KNOT_JSON,
+          error: error.response ? error.response.data.message : error.message
+        });
+      });
   };
 }

--- a/app/actions/knots.js
+++ b/app/actions/knots.js
@@ -141,7 +141,8 @@ export function save(
   knotName: string,
   selectedTap: TapPropertiesType,
   selectedTarget: { name: string, image: string },
-  currentName: string
+  currentName: string,
+  uuid: string
 ) {
   return (dispatch: (action: actionType) => void) => {
     dispatch({
@@ -153,7 +154,8 @@ export function save(
         knotName,
         tap: selectedTap,
         target: selectedTarget,
-        currentName
+        currentName,
+        uuid
       })
       .then(() =>
         dispatch({

--- a/app/actions/knots.js
+++ b/app/actions/knots.js
@@ -23,6 +23,8 @@
 
 import axios from 'axios';
 import { shell } from 'electron';
+import shortid from 'shortid';
+
 import type { TapPropertiesType } from '../utils/sharedTypes';
 
 const baseUrl = 'http://localhost:4321';
@@ -46,6 +48,7 @@ export const LOADING_KNOT = 'LOADING_KNOT';
 export const LOADED_KNOT = 'LOADED_KNOT';
 export const RESET_STORE = 'RESET_STORE';
 export const RESET_KNOT_ERROR = 'RESET_KNOT_ERROR';
+export const GENERATED_UUID = 'GENERATED_UUID';
 
 type actionType = {
   +type: string
@@ -306,6 +309,15 @@ export function resetKnotError() {
   return (dispatch: (action: actionType) => void) => {
     dispatch({
       type: RESET_KNOT_ERROR
+    });
+  };
+}
+
+export function generateUUID() {
+  return (dispatch: (action: actionType) => void) => {
+    dispatch({
+      type: GENERATED_UUID,
+      uuid: shortid.generate()
     });
   };
 }

--- a/app/actions/knots.js
+++ b/app/actions/knots.js
@@ -264,13 +264,13 @@ export function downloadKnot(knot: string) {
       .catch();
 }
 
-export function loadValues(knot: string) {
+export function loadValues(knot: string, uuid: string) {
   return (dispatch: (action: actionType) => void) => {
     dispatch({
       type: LOADING_KNOT
     });
     return axios
-      .post(`${baseUrl}/knots/load`, { knot })
+      .post(`${baseUrl}/knots/load`, { knot, uuid })
       .then((response) => {
         dispatch({
           type: LOADED_KNOT,

--- a/app/actions/taps.js
+++ b/app/actions/taps.js
@@ -149,6 +149,7 @@ export function updateTapField(
 export function submitConfig(
   tap: { name: string, image: string },
   config: { start_date?: string },
+  uuid: string,
   knotName: string,
   skipDiscovery: ?boolean
 ) {
@@ -161,6 +162,7 @@ export function submitConfig(
     const payload = {
       tap,
       tapConfig,
+      uuid,
       knot: knotName,
       skipDiscovery
     };

--- a/app/actions/taps.js
+++ b/app/actions/taps.js
@@ -202,12 +202,12 @@ export function editSchemaField(
   };
 }
 
-export function submitSchema(schema: {}, knot: string) {
+export function submitSchema(schema: {}, uuid: string) {
   return (dispatch: (action: actionType) => void) =>
     axios
       .put(`${baseUrl}/taps/schema/`, {
         schema: { streams: schema },
-        knot
+        uuid
       })
       .then(() => {
         dispatch({

--- a/app/actions/taps.js
+++ b/app/actions/taps.js
@@ -94,11 +94,16 @@ export function fetchTaps() {
   };
 }
 
-export function selectTap(tap: TapPropertiesType, knotName: string) {
+export function selectTap(
+  tap: TapPropertiesType,
+  uuid: string,
+  knotName: string
+) {
   return (dispatch: (action: actionType) => void) =>
     axios
       .post(`${baseUrl}/taps/select/`, {
         tap,
+        uuid,
         knot: knotName
       })
       .then(() => {

--- a/app/actions/targets.js
+++ b/app/actions/targets.js
@@ -72,7 +72,8 @@ export function getTargets() {
 
 export function selectTarget(
   target: { name: string, image: string },
-  knot: string
+  uuid: string,
+  knot: ?string
 ) {
   return (dispatch: (action: actionType) => void) => {
     dispatch({
@@ -81,7 +82,7 @@ export function selectTarget(
     });
 
     return axios
-      .post(`${baseUrl}/targets/select`, { target, knot })
+      .post(`${baseUrl}/targets/select`, { target, uuid, knot })
       .then(() => {
         dispatch({
           type: TARGET_INSTALLED
@@ -96,14 +97,14 @@ export function selectTarget(
   };
 }
 
-export function submitFields(fieldValues: {}, knot: string) {
+export function submitFields(fieldValues: {}, uuid: string) {
   return (dispatch: (action: actionType) => void) => {
     dispatch({
       type: TARGET_CONFIGURING
     });
 
     return axios
-      .post(`${baseUrl}/targets/`, { fieldValues, knot })
+      .post(`${baseUrl}/targets/`, { fieldValues, uuid })
       .then(() => {
         dispatch({
           type: TARGET_CONFIGURED

--- a/app/backend/knots.js
+++ b/app/backend/knots.js
@@ -160,25 +160,27 @@ const sync = (req, mode) =>
       .catch(reject);
   });
 
-const saveKnot = (name, currentName) =>
+const saveKnot = (name, uuid, currentName) =>
   new Promise((resolve, reject) => {
-    const pathToKnot = path.resolve(getTemporaryKnotFolder(), 'knot.json');
+    const pathToKnot = path.resolve(getTemporaryKnotFolder(uuid), 'knot.json');
 
     addKnotAttribute({ field: ['name'], value: name }, pathToKnot)
       .then(() => {
         readFile(pathToKnot)
           .then((knotObjectString) => {
             try {
-              const knotObject = JSON.parse(knotObjectString);
-              shell.mkdir('-p', path.resolve(getKnotsFolder(), name));
-              shell.mv(
-                path.resolve(getTemporaryKnotFolder(), '*'),
-                path.resolve(getKnotsFolder(), name)
-              );
-              if (currentName && currentName !== name) {
+              if (currentName) {
                 // Remove the knot that has been edited
                 shell.rm('-rf', path.resolve(getKnotsFolder(), currentName));
               }
+
+              const knotObject = JSON.parse(knotObjectString);
+              shell.mkdir('-p', path.resolve(getKnotsFolder(), name));
+              shell.mv(
+                path.resolve(getTemporaryKnotFolder(uuid), '*'),
+                path.resolve(getKnotsFolder(), name)
+              );
+
               // Add a make file to the folder
               writeFile(
                 path.resolve(getKnotsFolder(), name, 'Makefile'),

--- a/app/backend/knots.js
+++ b/app/backend/knots.js
@@ -305,6 +305,26 @@ const loadValues = (knot, uuid) =>
       .catch(reject);
   });
 
+const loadKnot = (knot) =>
+  new Promise((resolve, reject) => {
+    const knotPath = path.resolve(getKnotsFolder(), knot, 'knot.json');
+
+    readFile(knotPath)
+      .then((knotString) => {
+        try {
+          const knotJson = JSON.parse(knotString);
+
+          resolve({
+            tap: knotJson.tap,
+            target: knotJson.target
+          });
+        } catch (error) {
+          reject(error);
+        }
+      })
+      .catch(reject);
+  });
+
 const terminateSync = () => {
   if (runningProcess) {
     return runningProcess.pid;
@@ -329,6 +349,7 @@ module.exports = {
   packageKnot,
   downloadKnot,
   loadValues,
+  loadKnot,
   terminateSync,
   cancel
 };

--- a/app/backend/knots.js
+++ b/app/backend/knots.js
@@ -248,17 +248,17 @@ const downloadKnot = (req, res) => {
   res.download(`${path.resolve(getApplicationFolder(), 'tmp')}/${knot}.zip`);
 };
 
-const loadValues = (knot) =>
+const loadValues = (knot, uuid) =>
   new Promise((resolve, reject) => {
-    createTemporaryKnotFolder();
+    createTemporaryKnotFolder(uuid);
     // Make a clone of the knot to be edited
     shell.cp(
       '-R',
       path.resolve(getKnotsFolder(), knot, '*'),
-      path.resolve(getTemporaryKnotFolder())
+      path.resolve(getTemporaryKnotFolder(uuid))
     );
 
-    const knotPath = getTemporaryKnotFolder();
+    const knotPath = getTemporaryKnotFolder(uuid);
 
     const promises = [
       readFile(`${knotPath}/knot.json`),
@@ -304,10 +304,10 @@ const terminateSync = () => {
   }
 };
 
-const cancel = () =>
+const cancel = (uuid) =>
   new Promise((resolve, reject) => {
     try {
-      shell.rm('-rf', getTemporaryKnotFolder());
+      shell.rm('-rf', getTemporaryKnotFolder(uuid));
       resolve();
     } catch (error) {
       reject(error);

--- a/app/backend/knots.js
+++ b/app/backend/knots.js
@@ -42,6 +42,8 @@ let runningProcess;
 
 const getKnots = () =>
   new Promise((resolve, reject) => {
+    // App starting up, clear all temp files
+    shell.rm('-rf', path.resolve(getApplicationFolder(), 'tmp'));
     const knotsFolder = getKnotsFolder();
 
     try {

--- a/app/backend/knots.js
+++ b/app/backend/knots.js
@@ -181,6 +181,11 @@ const saveKnot = (name, uuid, currentName) =>
                 path.resolve(getKnotsFolder(), name)
               );
 
+              shell.rm(
+                '-rf',
+                path.resolve(getApplicationFolder(), 'tmp', uuid)
+              );
+
               // Add a make file to the folder
               writeFile(
                 path.resolve(getKnotsFolder(), name, 'Makefile'),

--- a/app/backend/routes/knots.js
+++ b/app/backend/routes/knots.js
@@ -110,9 +110,9 @@ router.post('/partial-sync/', (req, res) => {
 
 router.post('/load/', (req, res) => {
   // eslint-disable-next-line
-  const { knot } = req.body;
+  const { knot, uuid } = req.body;
 
-  loadValues(knot)
+  loadValues(knot, uuid)
     .then((result) => {
       res.json(result);
     })

--- a/app/backend/routes/knots.js
+++ b/app/backend/routes/knots.js
@@ -41,9 +41,9 @@ router.get('/', (req, res) => {
 });
 
 router.post('/save/', (req, res) => {
-  const { knotName, currentName } = req.body;
+  const { knotName, currentName, uuid } = req.body;
 
-  saveKnot(knotName, currentName)
+  saveKnot(knotName, uuid, currentName)
     .then(() => {
       sync(req)
         .then(() => {

--- a/app/backend/routes/knots.js
+++ b/app/backend/routes/knots.js
@@ -29,6 +29,7 @@ const {
   packageKnot,
   downloadKnot,
   loadValues,
+  loadKnot,
   cancel
 } = require('../knots');
 
@@ -109,10 +110,21 @@ router.post('/partial-sync/', (req, res) => {
 });
 
 router.post('/load/', (req, res) => {
-  // eslint-disable-next-line
   const { knot, uuid } = req.body;
 
   loadValues(knot, uuid)
+    .then((result) => {
+      res.json(result);
+    })
+    .catch((error) => {
+      res.status(500).json({ message: error.message });
+    });
+});
+
+router.post('/loadknot/', (req, res) => {
+  const { knot } = req.body;
+
+  loadKnot(knot)
     .then((result) => {
       res.json(result);
     })

--- a/app/backend/routes/taps.js
+++ b/app/backend/routes/taps.js
@@ -32,9 +32,9 @@ router.get('/', (req, res) => {
 });
 
 router.post('/select', (req, res) => {
-  const { tap, knot } = req.body;
+  const { tap, knot, uuid } = req.body;
 
-  createKnot(tap, !!knot)
+  createKnot(tap, uuid, !!knot)
     .then(() => {
       res.json({});
     })

--- a/app/backend/routes/taps.js
+++ b/app/backend/routes/taps.js
@@ -54,7 +54,7 @@ router.post('/config/', (req, res) => {
 });
 
 router.put('/schema/', (req, res) => {
-  writeSchema(req.body.schema, req.body.knot)
+  writeSchema(req.body.schema, req.body.uuid)
     .then(() => {
       res.json({});
     })

--- a/app/backend/routes/targets.js
+++ b/app/backend/routes/targets.js
@@ -39,7 +39,7 @@ router.get('/', (req, res) => {
 
 router.post('/', (req, res) => {
   const configPath = path.resolve(
-    getTemporaryKnotFolder(),
+    getTemporaryKnotFolder(req.body.uuid),
     'target',
     'config.json'
   );
@@ -52,7 +52,11 @@ router.post('/', (req, res) => {
 });
 
 router.post('/select', (req, res) => {
-  addKnotAttribute({ field: 'target', value: req.body.target })
+  addKnotAttribute(
+    { field: 'target', value: req.body.target },
+    null,
+    req.body.uuid
+  )
     .then(() => {
       res.json({});
     })

--- a/app/backend/taps.js
+++ b/app/backend/taps.js
@@ -36,7 +36,7 @@ const { taps, commands } = require('./constants');
 
 let runningProcess;
 
-const createKnot = (tap, modifyKnot) =>
+const createKnot = (tap, uuid, modifyKnot) =>
   new Promise((resolve, reject) => {
     if (modifyKnot) {
       addKnotAttribute(
@@ -48,7 +48,7 @@ const createKnot = (tap, modifyKnot) =>
             specImplementation: tap.specImplementation
           }
         },
-        path.resolve(getTemporaryKnotFolder(), 'knot.json')
+        path.resolve(getTemporaryKnotFolder(uuid), 'knot.json')
       )
         .then(() => {
           resolve();
@@ -56,10 +56,10 @@ const createKnot = (tap, modifyKnot) =>
         .catch(reject);
     } else {
       // Create new temporary knot folder
-      createTemporaryKnotFolder();
+      createTemporaryKnotFolder(uuid);
 
       writeFile(
-        path.resolve(getTemporaryKnotFolder(), 'knot.json'),
+        path.resolve(getTemporaryKnotFolder(uuid), 'knot.json'),
         JSON.stringify({
           tap: {
             name: tap.name,
@@ -78,7 +78,7 @@ const createKnot = (tap, modifyKnot) =>
 const getSchema = (req, mockSpawn) =>
   new Promise((resolve, reject) => {
     const spawnFunction = mockSpawn || spawn;
-    const knotPath = getTemporaryKnotFolder();
+    const knotPath = getTemporaryKnotFolder(req.body.uuid);
 
     shell.rm('-rf', path.resolve(knotPath, 'tap', 'catalog.json'));
     shell.mkdir('-p', path.resolve(knotPath, 'tap'));
@@ -122,11 +122,11 @@ const getSchema = (req, mockSpawn) =>
     });
   });
 
-const readSchema = (knot) =>
+const readSchema = (knot, uuid) =>
   new Promise((resolve, reject) => {
     const schemaPath = knot
       ? path.resolve(getKnotsFolder(), knot, 'tap', 'catalog.json')
-      : path.resolve(getTemporaryKnotFolder(), 'tap', 'catalog.json');
+      : path.resolve(getTemporaryKnotFolder(uuid), 'tap', 'catalog.json');
     readFile(schemaPath)
       .then((schemaString) => {
         try {
@@ -145,10 +145,10 @@ const readSchema = (knot) =>
 
 const addConfig = (req) =>
   new Promise((resolve, reject) => {
-    const { tapConfig, skipDiscovery } = req.body;
+    const { tapConfig, uuid, skipDiscovery } = req.body;
 
     const configPath = path.resolve(
-      getTemporaryKnotFolder(),
+      getTemporaryKnotFolder(uuid),
       'tap',
       'config.json'
     );
@@ -183,11 +183,11 @@ const getTaps = () =>
     }
   });
 
-const writeSchema = (schemaObject) =>
+const writeSchema = (schemaObject, uuid) =>
   new Promise((resolve, reject) => {
-    shell.mkdir('-p', path.resolve(getTemporaryKnotFolder(), 'tap'));
+    shell.mkdir('-p', path.resolve(getTemporaryKnotFolder(uuid), 'tap'));
     const catalogPath = path.resolve(
-      getTemporaryKnotFolder(),
+      getTemporaryKnotFolder(uuid),
       'tap',
       'catalog.json'
     );

--- a/app/backend/taps.js
+++ b/app/backend/taps.js
@@ -28,7 +28,6 @@ const {
   writeFile,
   readFile,
   addKnotAttribute,
-  getKnotsFolder,
   createTemporaryKnotFolder,
   getTemporaryKnotFolder
 } = require('./util');
@@ -122,11 +121,13 @@ const getSchema = (req, mockSpawn) =>
     });
   });
 
-const readSchema = (knot, uuid) =>
+const readSchema = (uuid) =>
   new Promise((resolve, reject) => {
-    const schemaPath = knot
-      ? path.resolve(getKnotsFolder(), knot, 'tap', 'catalog.json')
-      : path.resolve(getTemporaryKnotFolder(uuid), 'tap', 'catalog.json');
+    const schemaPath = path.resolve(
+      getTemporaryKnotFolder(uuid),
+      'tap',
+      'catalog.json'
+    );
     readFile(schemaPath)
       .then((schemaString) => {
         try {
@@ -162,7 +163,7 @@ const addConfig = (req) =>
           getSchema(req)
             .then(() => {
               // Schema now on file, read it and return the result
-              readSchema()
+              readSchema(req.body.uuid)
                 .then(resolve)
                 .catch(reject);
             })

--- a/app/backend/util.js
+++ b/app/backend/util.js
@@ -45,20 +45,23 @@ const getApplicationFolder = () => {
   return applicationFolder;
 };
 
-const createTemporaryKnotFolder = () => {
-  shell.rm('-rf', path.resolve(getApplicationFolder(), 'tmp', 'knot'));
+const createTemporaryKnotFolder = (uuid) => {
+  shell.rm('-rf', path.resolve(getApplicationFolder(), 'tmp'));
 
-  shell.mkdir('-p', path.resolve(getApplicationFolder(), 'tmp', 'knot'));
-  shell.mkdir('-p', path.resolve(getApplicationFolder(), 'tmp', 'knot', 'tap'));
+  shell.mkdir('-p', path.resolve(getApplicationFolder(), 'tmp', uuid, 'knot'));
   shell.mkdir(
     '-p',
-    path.resolve(getApplicationFolder(), 'tmp', 'knot', 'target')
+    path.resolve(getApplicationFolder(), 'tmp', uuid, 'knot', 'tap')
+  );
+  shell.mkdir(
+    '-p',
+    path.resolve(getApplicationFolder(), 'tmp', uuid, 'knot', 'target')
   );
 };
 
 const getKnotsFolder = () => path.resolve(getApplicationFolder(), 'knots');
-const getTemporaryKnotFolder = () =>
-  path.resolve(getApplicationFolder(), 'tmp', 'knot');
+const getTemporaryKnotFolder = (uuid) =>
+  path.resolve(getApplicationFolder(), 'tmp', uuid, 'knot');
 
 const readFile = (filePath) =>
   new Promise((resolve, reject) => {
@@ -83,10 +86,10 @@ const writeFile = (filePath, content) =>
     });
   });
 
-const addKnotAttribute = (content, knotPath) =>
+const addKnotAttribute = (content, knotPath, uuid) =>
   new Promise((resolve, reject) => {
     const pathToKnot =
-      knotPath || path.resolve(getTemporaryKnotFolder(), 'knot.json');
+      knotPath || path.resolve(getTemporaryKnotFolder(uuid), 'knot.json');
     readFile(pathToKnot)
       .then((knotObjectString) => {
         try {

--- a/app/components/Home/Create/index.js
+++ b/app/components/Home/Create/index.js
@@ -28,7 +28,8 @@ import { shell } from 'electron';
 
 type Props = {
   dockerInstalled: boolean,
-  dockerRunning: boolean
+  dockerRunning: boolean,
+  generateUUID: () => void
 };
 
 class Create extends Component<Props> {
@@ -38,7 +39,7 @@ class Create extends Component<Props> {
   };
 
   render() {
-    const { dockerInstalled, dockerRunning } = this.props;
+    const { dockerInstalled, dockerRunning, generateUUID } = this.props;
 
     return (
       <Jumbotron>
@@ -57,6 +58,7 @@ class Create extends Component<Props> {
             color="primary"
             disabled={!dockerInstalled || !dockerRunning}
             className="mt-3"
+            onClick={generateUUID}
           >
             Get Started
           </Button>

--- a/app/components/Home/Knots/Knot/index.js
+++ b/app/components/Home/Knots/Knot/index.js
@@ -35,7 +35,7 @@ type Props = {
   dockerInstalled: boolean,
   dockerRunning: boolean,
   history: { push: (path: string) => void },
-  loadValues: (name: string) => void,
+  loadKnot: (name: string) => void,
   generateUUID: () => void,
   toggleDelete: (knot: KnotType) => void,
   toggleDownloadDisclaimer: (knot: KnotType) => void
@@ -45,13 +45,13 @@ class Knot extends Component<Props> {
   fullSync = () => {
     const { knot } = this.props;
     this.props.history.push(`/saved-sync?knot=${knot.name}&mode=full`);
-    this.props.loadValues(knot.name);
+    this.props.loadKnot(knot.name);
   };
 
   partialSync = () => {
     const { knot } = this.props;
     this.props.history.push(`/saved-sync?knot=${knot.name}&mode=partial`);
-    this.props.loadValues(knot.name);
+    this.props.loadKnot(knot.name);
   };
 
   edit = () => {

--- a/app/components/Home/Knots/Knot/index.js
+++ b/app/components/Home/Knots/Knot/index.js
@@ -36,6 +36,7 @@ type Props = {
   dockerRunning: boolean,
   history: { push: (path: string) => void },
   loadValues: (name: string) => void,
+  generateUUID: () => void,
   toggleDelete: (knot: KnotType) => void,
   toggleDownloadDisclaimer: (knot: KnotType) => void
 };
@@ -54,9 +55,13 @@ class Knot extends Component<Props> {
   };
 
   edit = () => {
+    this.props.generateUUID();
     const { name } = this.props.knot;
-    this.props.history.push('/taps');
-    this.props.loadValues(name);
+    this.props.history.push(`/taps?knot=${name}`);
+    this.props.history.push({
+      pathname: '/taps',
+      state: { name }
+    });
   };
 
   render() {

--- a/app/components/Home/Knots/index.js
+++ b/app/components/Home/Knots/index.js
@@ -42,6 +42,7 @@ type Props = {
   downloadKnot: (knot: string) => void,
   getKnots: () => void,
   loadValues: (knot: string) => void,
+  generateUUID: () => void,
   toggleDelete: (knot: KnotType) => void,
   toggleDownloadDisclaimer: (knot: KnotType) => void
 };
@@ -67,7 +68,7 @@ class Knots extends Component<Props> {
 
   render() {
     const { knots, knotError, knotLoaded } = this.props.knotsStore;
-    const { dockerInstalled, dockerRunning } = this.props;
+    const { dockerInstalled, dockerRunning, generateUUID } = this.props;
 
     if (knotLoaded && !knotError) {
       this.props.history.push('/taps');
@@ -83,6 +84,7 @@ class Knots extends Component<Props> {
               disabled={!dockerInstalled || !dockerRunning}
               size="sm"
               className="float-right"
+              onClick={generateUUID}
             >
               New knot
             </Button>
@@ -122,6 +124,7 @@ class Knots extends Component<Props> {
                 dockerRunning={dockerRunning}
                 toggleDelete={this.props.toggleDelete}
                 toggleDownloadDisclaimer={this.props.toggleDownloadDisclaimer}
+                generateUUID={this.props.generateUUID}
               />
             ))}
           </tbody>

--- a/app/components/Home/Knots/index.js
+++ b/app/components/Home/Knots/index.js
@@ -42,6 +42,7 @@ type Props = {
   downloadKnot: (knot: string) => void,
   getKnots: () => void,
   loadValues: (knot: string) => void,
+  loadKnot: (knot: string) => void,
   generateUUID: () => void,
   toggleDelete: (knot: KnotType) => void,
   toggleDownloadDisclaimer: (knot: KnotType) => void
@@ -64,6 +65,10 @@ class Knots extends Component<Props> {
 
   loadValues = (knot: string) => {
     this.props.loadValues(knot);
+  };
+
+  loadKnot = (knot: string) => {
+    this.props.loadKnot(knot);
   };
 
   render() {
@@ -120,6 +125,7 @@ class Knots extends Component<Props> {
                 delete={this.delete}
                 download={this.download}
                 loadValues={this.loadValues}
+                loadKnot={this.loadKnot}
                 dockerInstalled={dockerInstalled}
                 dockerRunning={dockerRunning}
                 toggleDelete={this.props.toggleDelete}

--- a/app/components/Home/index.js
+++ b/app/components/Home/index.js
@@ -53,7 +53,8 @@ type Props = {
   },
   resetStore: () => void,
   deleteKnot: (knot: string) => void,
-  downloadKnot: (knot: string) => void
+  downloadKnot: (knot: string) => void,
+  generateUUID: () => void
 };
 
 type State = {
@@ -212,7 +213,12 @@ export default class Home extends Component<Props, State> {
                   toggleDownloadDisclaimer={this.toggleDownloadDisclaimer}
                 />
               )}
-              {knots.length === 0 && <Create {...this.state} />}
+              {knots.length === 0 && (
+                <Create
+                  {...this.state}
+                  generateUUID={this.props.generateUUID}
+                />
+              )}
             </div>
           )}
         </Container>

--- a/app/components/Schema/index.js
+++ b/app/components/Schema/index.js
@@ -59,14 +59,14 @@ type Props = {
     selectedTap: tapPropertiesType,
     error?: string
   },
-  knotsStore: { knotName: string, knotName: string },
+  knotsStore: { knotName: string, uuid: string },
   editSchemaField: (
     field: string,
     index: string,
     value: boolean | string,
     specImplementation: specImplementationPropType
   ) => void,
-  submitSchema: (schema: Array<Stream>, knotName: string) => void,
+  submitSchema: (schema: Array<Stream>, uuid: string) => void,
   submitConfig: (
     selectedTap: { name: string, image: string },
     fieldValues: {},
@@ -150,9 +150,9 @@ export default class Schema extends Component<Props, State> {
 
   submit = () => {
     // TODO Ask for confirmation if no timestamp fields are selected when they are available
-    const { knotName } = this.props.knotsStore;
+    const { uuid } = this.props.knotsStore;
     if (this.validSchema()) {
-      this.props.submitSchema(this.props.tapsStore.schema, knotName);
+      this.props.submitSchema(this.props.tapsStore.schema, uuid);
       this.props.history.push('/targets');
     } else {
       this.setState({ streamSelected: !this.validSchema() });

--- a/app/components/Sync/index.js
+++ b/app/components/Sync/index.js
@@ -212,7 +212,7 @@ export default class Sync extends Component<Props, State> {
     const { knotName, uuid } = this.props.knotsStore;
 
     this.props.save(
-      knotName,
+      knotName.trim(),
       selectedTap,
       selectedTarget,
       this.state.currentKnotName,

--- a/app/components/Sync/index.js
+++ b/app/components/Sync/index.js
@@ -67,7 +67,8 @@ type Props = {
     tapLogs: Array<string>,
     targetLogs: Array<string>,
     knotError: string,
-    knotLoaded: boolean
+    knotLoaded: boolean,
+    uuid: string
   },
   tapStore: {
     selectedTap: TapPropertiesType
@@ -80,7 +81,8 @@ type Props = {
     knotName: string,
     selectedTap: TapPropertiesType,
     selectedTarget: { name: string, image: string },
-    currentName: string
+    currentName: string,
+    uuid: string
   ) => void,
   updateTapLogs: (log: string) => void,
   updateTargetLogs: (log: string) => void,
@@ -206,13 +208,14 @@ export default class Sync extends Component<Props, State> {
   submit = () => {
     const { selectedTap } = this.props.tapStore;
     const { selectedTarget } = this.props.targetsStore;
-    const { knotName } = this.props.knotsStore;
+    const { knotName, uuid } = this.props.knotsStore;
 
     this.props.save(
       knotName,
       selectedTap,
       selectedTarget,
-      this.state.currentKnotName
+      this.state.currentKnotName,
+      uuid
     );
   };
 

--- a/app/components/Sync/index.js
+++ b/app/components/Sync/index.js
@@ -92,7 +92,8 @@ type Props = {
   history: { push: (path: string) => void },
   syncPageLoaded: () => void,
   cancel: (name: string) => void,
-  resetKnotError: () => void
+  resetKnotError: () => void,
+  loadValues: (name: string, uuid: string) => void
 };
 
 type State = {
@@ -230,7 +231,8 @@ export default class Sync extends Component<Props, State> {
       knotName,
       tapLogs,
       targetLogs,
-      knotError
+      knotError,
+      uuid
     } = this.props.knotsStore;
     const { selectedTap } = this.props.tapStore;
     const { selectedTarget } = this.props.targetsStore;
@@ -315,6 +317,7 @@ export default class Sync extends Component<Props, State> {
               to="/taps"
               className="btn btn-outline-danger align-self-center"
               onClick={() => {
+                this.props.loadValues(knotName, uuid);
                 this.props.resetKnotError();
               }}
             >

--- a/app/components/Taps/Tap/index.js
+++ b/app/components/Taps/Tap/index.js
@@ -37,8 +37,9 @@ type Props = {
   selected: string,
   repo: string,
   specImplementation?: SpecImplementationPropType,
-  selectTap: (tap: TapPropertiesType, knotName: string) => void,
-  knotName: string
+  selectTap: (tap: TapPropertiesType, knotName: string, uuid: string) => void,
+  knotName: string,
+  uuid: string
 };
 
 type State = {
@@ -92,6 +93,7 @@ export default class Tap extends Component<Props, State> {
                 repo,
                 specImplementation
               },
+              this.props.uuid,
               knotName
             );
           }}

--- a/app/components/Taps/index.js
+++ b/app/components/Taps/index.js
@@ -55,7 +55,7 @@ type Props = {
       repo: string
     }>
   },
-  knotsStore: { knotName: string, knotLoaded: boolean },
+  knotsStore: { knotName: string, uuid: string, knotLoaded: boolean },
   history: { push: (path: string) => void },
   selectTap: (tap: TapPropertiesType) => void,
   submitConfig: (
@@ -162,6 +162,7 @@ export default class Taps extends Component<Props, State> {
           selectTap={this.props.selectTap}
           selected={selectedTap.name}
           knotName={knotName}
+          uuid={this.props.knotsStore.uuid}
         />
       );
       const lastTapInRow = (i + 1) % 3 === 0;

--- a/app/components/Taps/index.js
+++ b/app/components/Taps/index.js
@@ -57,6 +57,7 @@ type Props = {
   },
   knotsStore: { knotName: string, uuid: string, knotLoaded: boolean },
   history: { push: (path: string) => void },
+  location: { state?: {} },
   selectTap: (tap: TapPropertiesType) => void,
   submitConfig: (
     selectedTap: TapPropertiesType,
@@ -65,6 +66,7 @@ type Props = {
     skipDiscovery: ?boolean
   ) => void,
   tapsPageLoaded: () => void,
+  loadValues: (knot: string, uuid: string) => void,
   cancel: (name: string) => void
 };
 
@@ -80,8 +82,14 @@ export default class Taps extends Component<Props, State> {
   };
 
   componentWillMount() {
+    const { name } = this.props.location.state || {};
     this.props.tapsPageLoaded();
     this.props.fetchTaps();
+
+    if (name) {
+      const { uuid } = this.props.knotsStore;
+      this.props.loadValues(name, uuid);
+    }
   }
 
   componentWillReceiveProps(nextProps: Props) {

--- a/app/components/Taps/index.js
+++ b/app/components/Taps/index.js
@@ -126,6 +126,7 @@ export default class Taps extends Component<Props, State> {
       this.props.submitConfig(
         selectedTap,
         fieldValues,
+        this.props.knotsStore.uuid,
         knotName,
         skipDiscovery
       );

--- a/app/components/Targets/Target/index.js
+++ b/app/components/Targets/Target/index.js
@@ -33,8 +33,10 @@ type Props = {
   selected: string,
   selectTarget: (
     tap: { name: string, image: string },
+    uuid: string,
     knotName: string
   ) => void,
+  uuid: string,
   knotName: string
 };
 
@@ -61,7 +63,7 @@ export default class Target extends Component<Props, State> {
   };
 
   render() {
-    const { targetKey, knotName, name } = this.props;
+    const { targetKey, targetImage, uuid, knotName, name } = this.props;
     return (
       <Col sm="12" md={{ size: 4 }}>
         <Card
@@ -73,8 +75,9 @@ export default class Target extends Component<Props, State> {
             this.props.selectTarget(
               {
                 name: targetKey,
-                image: this.props.targetImage
+                image: targetImage
               },
+              uuid,
               knotName
             );
           }}

--- a/app/components/Targets/index.js
+++ b/app/components/Targets/index.js
@@ -47,10 +47,10 @@ type Props = {
     'target-stitch': { fieldValues: {} },
     'target-datadotworld': { fieldValues: {} }
   },
-  knotsStore: { knotName: string },
+  knotsStore: { knotName: string, uuid: string },
   history: { push: (path: string) => void },
-  selectTarget: (target: { name: string, image: string }) => void,
-  submitFields: (fielsValues: {}, knotName: string) => void,
+  selectTarget: (target: { name: string, image: string }, uuid: string) => void,
+  submitFields: (fielsValues: {}, uuid: string, knotName: string) => void,
   targetsPageLoaded: () => void,
   cancel: (knot: string) => void
 };
@@ -109,9 +109,9 @@ export default class Targets extends Component<Props, State> {
   submit = () => {
     const { name } = this.props.targetsStore.selectedTarget;
     const { fieldValues } = this.props.userStore[name];
-    const { knotName } = this.props.knotsStore;
+    const { uuid } = this.props.knotsStore;
 
-    this.props.submitFields(fieldValues, knotName);
+    this.props.submitFields(fieldValues, uuid);
 
     this.props.history.push('/sync');
   };
@@ -119,7 +119,7 @@ export default class Targets extends Component<Props, State> {
   render() {
     const { showTargets } = this.state;
     const { targets, selectedTarget } = this.props.targetsStore;
-    const { knotName } = this.props.knotsStore;
+    const { knotName, uuid } = this.props.knotsStore;
 
     return (
       <div>
@@ -151,6 +151,7 @@ export default class Targets extends Component<Props, State> {
                       selectTarget={this.props.selectTarget}
                       selected={selectedTarget.name}
                       knotName={knotName}
+                      uuid={uuid}
                     />
                   ))}
                 </Row>

--- a/app/reducers/knots.js
+++ b/app/reducers/knots.js
@@ -34,7 +34,8 @@ import {
   LOADING_KNOT,
   DOCKER_RUNNING,
   RESET_STORE,
-  RESET_KNOT_ERROR
+  RESET_KNOT_ERROR,
+  GENERATED_UUID
 } from '../actions/knots';
 
 export type knotsStateType = {
@@ -54,10 +55,12 @@ export type knotsStateType = {
   +knotDeleted: boolean,
   +knotError: string,
   +knotLoading: boolean,
-  +knotLoaded: boolean
+  +knotLoaded: boolean,
+
+  +uuid: string
 };
 
-export const defaultState = {
+export const defaultState = () => ({
   detectingDocker: false,
   dockerVersion: '',
   dockerRunning: false,
@@ -74,10 +77,12 @@ export const defaultState = {
   knotDeleted: false,
   knotError: '',
   knotLoading: false,
-  knotLoaded: false
-};
+  knotLoaded: false,
 
-export default function knots(state = defaultState, action) {
+  uuid: ''
+});
+
+export default function knots(state = defaultState(), action) {
   switch (action.type) {
     case DETECTING_DOCKER:
       return Object.assign({}, state, {
@@ -153,27 +158,13 @@ export default function knots(state = defaultState, action) {
         knotSyncing: false,
         knotSynced: false
       });
+    case GENERATED_UUID:
+      return Object.assign({}, state, {
+        uuid: action.uuid
+      });
     case RESET_STORE:
       // Fact that objects are passed by reference makes this necessary, open to other suggestions
-      return {
-        detectingDocker: false,
-        dockerVersion: '',
-        dockerRunning: false,
-        dockerError: '',
-        dockerVerified: false,
-
-        fetchingKnots: false,
-        knots: [],
-        tapLogs: [],
-        targetLogs: [],
-        knotName: '',
-        knotSyncing: false,
-        knotSynced: false,
-        knotDeleted: false,
-        knotError: '',
-        knotLoading: false,
-        knotLoaded: false
-      };
+      return defaultState();
     default:
       return state;
   }

--- a/app/reducers/taps.js
+++ b/app/reducers/taps.js
@@ -34,7 +34,7 @@ import {
   UPDATE_TAPS,
   UPDATE_FORM_VALIDATION
 } from '../actions/taps';
-import { LOADED_KNOT, RESET_STORE } from '../actions/knots';
+import { LOADED_KNOT, RESET_STORE, LOADED_KNOT_JSON } from '../actions/knots';
 import type {
   TapPropertiesType,
   TapRedshift,
@@ -402,6 +402,10 @@ export default function taps(state = defaultState(), action) {
           })
         }
       );
+    case LOADED_KNOT_JSON:
+      return Object.assign({}, state, {
+        selectedTap: action.tap
+      });
     case UPDATE_FORM_VALIDATION:
       return Object.assign({}, state, {
         [action.tap]: Object.assign({}, state[action.tap], {

--- a/app/reducers/taps.js
+++ b/app/reducers/taps.js
@@ -107,6 +107,7 @@ export function defaultState() {
       }
     },
     'tap-postgres': {
+      valid: false,
       fieldValues: {
         host: '',
         port: undefined,
@@ -116,6 +117,7 @@ export function defaultState() {
       }
     },
     'tap-adwords': {
+      valid: false,
       fieldValues: {
         developer_token: '',
         oauth_client_id: '',
@@ -127,6 +129,7 @@ export function defaultState() {
       }
     },
     'tap-mysql': {
+      valid: false,
       fieldValues: {
         host: '',
         port: undefined,
@@ -136,6 +139,7 @@ export function defaultState() {
       }
     },
     'tap-facebook': {
+      valid: false,
       fieldValues: {
         access_token: '',
         account_id: '',
@@ -145,6 +149,7 @@ export function defaultState() {
       }
     },
     'tap-s3-csv': {
+      valid: false,
       fieldValues: {
         bucket: '',
         start_date: '',

--- a/app/reducers/targets.js
+++ b/app/reducers/targets.js
@@ -24,7 +24,7 @@ import {
   TARGETS_LOADING,
   TARGET_SELECTED
 } from '../actions/targets';
-import { LOADED_KNOT, RESET_STORE } from '../actions/knots';
+import { LOADED_KNOT, RESET_STORE, LOADED_KNOT_JSON } from '../actions/knots';
 
 export type targetsStateType = {
   +targets: Array<{}>,
@@ -60,6 +60,10 @@ export default function targets(state = defaultState(), action) {
         selectedTarget: action.target
       });
     case LOADED_KNOT:
+      return Object.assign({}, state, {
+        selectedTarget: action.target
+      });
+    case LOADED_KNOT_JSON:
       return Object.assign({}, state, {
         selectedTarget: action.target
       });

--- a/test/actions/taps.actions.spec.js
+++ b/test/actions/taps.actions.spec.js
@@ -103,6 +103,7 @@ describe('taps actions', () => {
         .defaultReplyHeaders({ 'Access-Control-Allow-Origin': '*' })
         .post('/select/', {
           tap: taps[0],
+          uuid: 'qwertyui',
           knot: 'tap'
         })
         .reply(200, {});
@@ -114,9 +115,11 @@ describe('taps actions', () => {
         }
       ];
 
-      return store.dispatch(tapActions.selectTap(taps[0], 'tap')).then(() => {
-        expect(store.getActions()).toEqual(expectedActions);
-      });
+      return store
+        .dispatch(tapActions.selectTap(taps[0], 'qwertyui', 'tap'))
+        .then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+        });
     });
 
     it('should dispatch TAP_SELECTED with errors', () => {

--- a/test/actions/taps.actions.spec.js
+++ b/test/actions/taps.actions.spec.js
@@ -172,8 +172,9 @@ describe('taps actions', () => {
         .defaultReplyHeaders({ 'Access-Control-Allow-Origin': '*' })
         .post('/config/', {
           tap: taps[0],
-          knot,
           tapConfig,
+          uuid: 'asdfgjk',
+          knot,
           skipDiscovery
         })
         .reply(200, { schema });
@@ -190,7 +191,13 @@ describe('taps actions', () => {
 
       return store
         .dispatch(
-          tapActions.submitConfig(taps[0], tapConfig, knot, skipDiscovery)
+          tapActions.submitConfig(
+            taps[0],
+            tapConfig,
+            'asdfgjk',
+            knot,
+            skipDiscovery
+          )
         )
         .then(() => {
           expect(store.getActions()).toEqual(expectedActions);

--- a/test/actions/targets.actions.spec.js
+++ b/test/actions/targets.actions.spec.js
@@ -79,7 +79,8 @@ describe('target actions', () => {
         .defaultReplyHeaders({ 'Access-Control-Allow-Origin': '*' })
         .post('/select', {
           target: sampleTargets[0],
-          knot: 'target'
+          knot: 'target',
+          uuid: 'targetUUID'
         })
         .reply(200, {});
 
@@ -94,7 +95,9 @@ describe('target actions', () => {
       ];
 
       return store
-        .dispatch(targetActions.selectTarget(sampleTargets[0], 'target'))
+        .dispatch(
+          targetActions.selectTarget(sampleTargets[0], 'targetUUID', 'target')
+        )
         .then(() => {
           expect(store.getActions()).toEqual(expectedActions);
         });
@@ -130,14 +133,13 @@ describe('target actions', () => {
   describe('submit fields', () => {
     it('should dispatch TARGET_CONFIGURING', () => {
       const store = mockStore({});
-      const knot = '';
       const fieldValues = { id: '1234' };
 
       nock(`${baseUrl}/targets/`)
         .defaultReplyHeaders({ 'Access-Control-Allow-Origin': '*' })
         .post('/', {
           fieldValues,
-          knot
+          uuid: 'uniqueUUID'
         })
         .reply(200, {});
 
@@ -151,7 +153,7 @@ describe('target actions', () => {
       ];
 
       return store
-        .dispatch(targetActions.submitFields(fieldValues, knot))
+        .dispatch(targetActions.submitFields(fieldValues, 'uniqueUUID'))
         .then(() => {
           expect(store.getActions()).toEqual(expectedActions);
         });

--- a/test/backend/knots.spec.js
+++ b/test/backend/knots.spec.js
@@ -48,7 +48,7 @@ describe('knots functions', () => {
           );
         })
         .catch((err) => {
-          expect(err).toBe(null);
+          expect(err).toBeUndefined();
         });
     });
 
@@ -90,8 +90,8 @@ describe('knots functions', () => {
 
   describe('cancel', () => {
     beforeAll((done) => {
-      shell.mkdir('-p', path.resolve('tmp', 'knot', 'tap'));
-      shell.mkdir('-p', path.resolve('tmp', 'knot', 'target'));
+      shell.mkdir('-p', path.resolve('tmp', 'cancelUUID', 'knot', 'tap'));
+      shell.mkdir('-p', path.resolve('tmp', 'cancelUUID', 'knot', 'target'));
       done();
     });
 
@@ -100,7 +100,7 @@ describe('knots functions', () => {
     });
 
     it('should delete the temporary knot', () => {
-      cancel()
+      cancel('cancelUUID')
         .then(() => {
           const getDirectories = (source) =>
             fs
@@ -111,7 +111,7 @@ describe('knots functions', () => {
               .map((folderPath) => path.basename(folderPath));
 
           // Array of knot names
-          const knots = getDirectories(path.resolve('tmp'));
+          const knots = getDirectories(path.resolve('tmp', 'cancelUUID'));
 
           expect(knots.length).toEqual(0);
         })
@@ -145,7 +145,8 @@ describe('knots functions', () => {
     });
 
     it('should load values of a saved knot', (done) => {
-      loadValues('savedKnot')
+      const uuid = Math.random().toString();
+      loadValues('savedKnot', uuid)
         .then((res) => {
           expect(res.name).toEqual(sampleSavedKnot.knotJson.name);
           expect(res.tap).toEqual(sampleSavedKnot.knotJson.tap);
@@ -163,7 +164,8 @@ describe('knots functions', () => {
     });
 
     it('should reject promise when there is an invalid file', (done) => {
-      loadValues('invalidSavedKnot')
+      const uuid = Math.random().toString();
+      loadValues('invalidSavedKnot', uuid)
         .then((res) => {
           expect(res).toBeUndefined();
           done();

--- a/test/backend/knots.spec.js
+++ b/test/backend/knots.spec.js
@@ -4,7 +4,9 @@ import shell from 'shelljs';
 
 import {
   getKnots,
+  loadKnot,
   loadValues,
+  saveKnot,
   deleteKnot,
   cancel,
   packageKnot
@@ -16,6 +18,7 @@ import {
   invalidKnotString,
   seedKnots,
   seedKnot,
+  seedTempKnot,
   seedInvalidKnot,
   cleanfs
 } from '../util';
@@ -121,6 +124,58 @@ describe('knots functions', () => {
     });
   });
 
+  describe('load knot', () => {
+    beforeAll((done) => {
+      seedKnot()
+        .then(() => {
+          seedInvalidKnot()
+            .then(() => {
+              done();
+            })
+            .catch((error) => {
+              expect(error).toBeUndefined();
+              done();
+            });
+        })
+        .catch((error) => {
+          expect(error).toBeUndefined();
+          done();
+        });
+    });
+
+    afterAll(() => {
+      cleanfs();
+    });
+
+    it('should load knot.json values of a saved knot', (done) => {
+      const uuid = Math.random().toString();
+      loadKnot('savedKnot', uuid)
+        .then((res) => {
+          expect(res.tap).toEqual(sampleSavedKnot.knotJson.tap);
+          expect(res.target).toEqual(sampleSavedKnot.knotJson.target);
+
+          done();
+        })
+        .catch((err) => {
+          expect(err).toBeUndefined();
+          done();
+        });
+    });
+
+    it('should reject promise when there is an invalid file', (done) => {
+      const uuid = Math.random().toString();
+      loadKnot('invalidSavedKnot', uuid)
+        .then((res) => {
+          expect(res).toBeUndefined();
+          done();
+        })
+        .catch((err) => {
+          expect(err).toBeDefined();
+          done();
+        });
+    });
+  });
+
   describe('load values', () => {
     beforeAll((done) => {
       seedKnot()
@@ -172,6 +227,66 @@ describe('knots functions', () => {
         })
         .catch((err) => {
           expect(err).toBeDefined();
+          done();
+        });
+    });
+  });
+
+  describe('save knot', () => {
+    beforeEach((done) => {
+      seedTempKnot()
+        .then(() => {
+          seedKnot()
+            .then(() => {
+              done();
+            })
+            .catch((error) => {
+              expect(error).toBeUndefined();
+              done();
+            });
+        })
+        .catch((error) => {
+          expect(error).toBeUndefined();
+          done();
+        });
+    });
+
+    afterAll(() => {
+      cleanfs();
+    });
+
+    it('should save specified knot inside knots folder', (done) => {
+      saveKnot('knotName', 'tempUUID')
+        .then(() => {
+          fs.access(
+            path.resolve('knots', 'knotName'),
+            fs.constants.F_OK,
+            (err) => {
+              expect(err).toBeNull();
+              done();
+            }
+          );
+        })
+        .catch((err) => {
+          expect(err).toBeUndefined();
+          done();
+        });
+    });
+
+    it('should delete edited knot', (done) => {
+      saveKnot('knotName', 'tempUUID', 'savedKnot')
+        .then(() => {
+          fs.access(
+            path.resolve('knots', 'savedKnot'),
+            fs.constants.F_OK,
+            (err) => {
+              expect(err).toBeDefined();
+              done();
+            }
+          );
+        })
+        .catch((err) => {
+          expect(err).toBeUndefined();
           done();
         });
     });

--- a/test/backend/taps.spec.js
+++ b/test/backend/taps.spec.js
@@ -41,10 +41,11 @@ describe('taps functions', () => {
     });
 
     it('should update saved knot', (done) => {
-      shell.mkdir('-p', path.resolve('tmp', 'knot'));
+      const uuid = Math.random().toString();
+      shell.mkdir('-p', path.resolve('tmp', uuid, 'knot'));
 
       fs.writeFile(
-        path.resolve('tmp', 'knot', 'knot.json'),
+        path.resolve('tmp', uuid, 'knot', 'knot.json'),
         JSON.stringify({}),
         (err) => {
           if (!err) {
@@ -54,11 +55,12 @@ describe('taps functions', () => {
                 image: 'new-tap-image',
                 specImplementation: {}
               },
+              uuid,
               true
             )
               .then(() => {
                 fs.readFile(
-                  path.resolve('tmp', 'knot', 'knot.json'),
+                  path.resolve('tmp', uuid, 'knot', 'knot.json'),
                   'utf8',
                   (er, data) => {
                     if (!er) {
@@ -95,14 +97,18 @@ describe('taps functions', () => {
     });
 
     it('should create a new knot json in a temp folder', (done) => {
-      createKnot({
-        name: 'new-tap',
-        image: 'new-tap-image',
-        specImplementation: {}
-      })
+      const uuid = Math.random().toString();
+      createKnot(
+        {
+          name: 'new-tap',
+          image: 'new-tap-image',
+          specImplementation: {}
+        },
+        uuid
+      )
         .then(() => {
           fs.readFile(
-            path.resolve('tmp', 'knot', 'knot.json'),
+            path.resolve('tmp', uuid, 'knot', 'knot.json'),
             'utf8',
             (err, data) => {
               if (!err) {
@@ -139,7 +145,8 @@ describe('taps functions', () => {
       getSchema(
         {
           body: {
-            tap: { name: 'tap-adwords', image: 'dataworld/tap-adwords:1.3.3' }
+            tap: { name: 'tap-adwords', image: 'dataworld/tap-adwords:1.3.3' },
+            uuid: 'schemaUUID'
           }
         },
         mySpawn
@@ -157,7 +164,11 @@ describe('taps functions', () => {
       getSchema(
         {
           body: {
-            tap: { name: 'tap-adwords', image: 'dataworld/tap-adwords:1.3.3' }
+            tap: {
+              name: 'tap-adwords',
+              image: 'dataworld/tap-adwords:1.3.3',
+              uuid: 'schemaUUID'
+            }
           }
         },
         mySpawn
@@ -188,7 +199,7 @@ describe('taps functions', () => {
     });
 
     it('should read a temporary knot schema', (done) => {
-      readSchema()
+      readSchema(null, 'uuid')
         .then((res) => {
           expect(res).toEqual(sampleTapCatalog);
           done();
@@ -241,10 +252,16 @@ describe('taps functions', () => {
     });
 
     it("should save a temp knot's tap config", (done) => {
-      addConfig({ body: { tapConfig: sampleTapConfig, skipDiscovery: false } })
+      addConfig({
+        body: {
+          tapConfig: sampleTapConfig,
+          skipDiscovery: false,
+          uuid: 'configUUID'
+        }
+      })
         .then(() => {
           fs.readFile(
-            path.resolve('tmp', 'knot', 'tap', 'config.json'),
+            path.resolve('tmp', 'configUUID', 'knot', 'tap', 'config.json'),
             (err, data) => {
               if (!err) {
                 const actual = data.toString();
@@ -270,12 +287,13 @@ describe('taps functions', () => {
           tapConfig: Object.assign({}, sampleTapConfig, {
             skipDiscovery: true
           }),
-          skipDiscovery: true
+          skipDiscovery: true,
+          uuid: 'configUUID'
         }
       })
         .then((res) => {
           fs.readFile(
-            path.resolve('tmp', 'knot', 'tap', 'config.json'),
+            path.resolve('tmp', 'configUUID', 'knot', 'tap', 'config.json'),
             (err, data) => {
               if (!err) {
                 const actual = data.toString();
@@ -314,11 +332,16 @@ describe('taps functions', () => {
   });
 
   describe('write schema', () => {
+    afterAll(() => {
+      cleanfs();
+    });
+
     it('should write tap catalog to file', (done) => {
-      writeSchema(sampleTapCatalog)
+      const uuid = Math.random().toString();
+      writeSchema(sampleTapCatalog, uuid)
         .then(() => {
           fs.readFile(
-            path.resolve('tmp', 'knot', 'tap', 'catalog.json'),
+            path.resolve('tmp', uuid, 'knot', 'tap', 'catalog.json'),
             (err, data) => {
               if (!err) {
                 const actual = data.toString();

--- a/test/backend/taps.spec.js
+++ b/test/backend/taps.spec.js
@@ -9,7 +9,6 @@ import {
   seedTapConfig,
   sampleTapCatalog,
   sampleTapConfig,
-  savedSampleTapCatalog,
   cleanfs
 } from '../util';
 import {
@@ -199,37 +198,13 @@ describe('taps functions', () => {
     });
 
     it('should read a temporary knot schema', (done) => {
-      readSchema(null, 'uuid')
+      readSchema('uuid')
         .then((res) => {
           expect(res).toEqual(sampleTapCatalog);
           done();
         })
         .catch((err) => {
           expect(err).toBeUndefined();
-          done();
-        });
-    });
-
-    it('should read a saved knot schema', (done) => {
-      readSchema('savedKnot')
-        .then((res) => {
-          expect(res).toEqual(savedSampleTapCatalog);
-          done();
-        })
-        .catch((err) => {
-          expect(err).toBeUndefined();
-          done();
-        });
-    });
-
-    it('should reject promise for invalid jsons', (done) => {
-      readSchema('invalidKnot')
-        .then(() => {
-          expect(true).toBe(false);
-          done();
-        })
-        .catch((err) => {
-          expect(err).toBeDefined();
           done();
         });
     });

--- a/test/reducers/knots.reducer.spec.js
+++ b/test/reducers/knots.reducer.spec.js
@@ -3,7 +3,7 @@ import * as knotActions from '../../app/actions/knots';
 
 describe('knots reducer', () => {
   it('should return the initial state', () => {
-    expect(knotReducer(undefined, {})).toEqual(defaultState);
+    expect(knotReducer(undefined, {})).toEqual(defaultState());
   });
 
   it('should handle DETECTING_DOCKER', () => {
@@ -12,7 +12,7 @@ describe('knots reducer', () => {
         type: knotActions.DETECTING_DOCKER
       })
     ).toEqual(
-      Object.assign({}, defaultState, {
+      Object.assign({}, defaultState(), {
         detectingDocker: true
       })
     );
@@ -26,7 +26,7 @@ describe('knots reducer', () => {
         error: false
       })
     ).toEqual(
-      Object.assign({}, defaultState, {
+      Object.assign({}, defaultState(), {
         dockerError: false,
         dockerVerified: false
       })
@@ -41,7 +41,7 @@ describe('knots reducer', () => {
         error: false
       })
     ).toEqual(
-      Object.assign({}, defaultState, {
+      Object.assign({}, defaultState(), {
         dockerRunning: true,
         dockerError: false,
         dockerVerified: true
@@ -55,7 +55,7 @@ describe('knots reducer', () => {
         type: knotActions.FETCHING_KNOTS
       })
     ).toEqual(
-      Object.assign({}, defaultState, {
+      Object.assign({}, defaultState(), {
         fetchingKnots: true,
         knotDeleted: false
       })
@@ -69,7 +69,7 @@ describe('knots reducer', () => {
         knots: []
       })
     ).toEqual(
-      Object.assign({}, defaultState, {
+      Object.assign({}, defaultState(), {
         fetchingKnots: false,
         knots: []
       })
@@ -83,7 +83,7 @@ describe('knots reducer', () => {
         newLog: 'showing tap logs'
       })
     ).toEqual(
-      Object.assign({}, defaultState, {
+      Object.assign({}, defaultState(), {
         tapLogs: ['showing tap logs']
       })
     );
@@ -96,7 +96,7 @@ describe('knots reducer', () => {
         newLog: 'showing target logs'
       })
     ).toEqual(
-      Object.assign({}, defaultState, {
+      Object.assign({}, defaultState(), {
         targetLogs: ['showing target logs']
       })
     );
@@ -109,7 +109,7 @@ describe('knots reducer', () => {
         name: 'knotname'
       })
     ).toEqual(
-      Object.assign({}, defaultState, {
+      Object.assign({}, defaultState(), {
         knotName: 'knotname'
       })
     );
@@ -121,7 +121,7 @@ describe('knots reducer', () => {
         type: knotActions.KNOT_SYNCING
       })
     ).toEqual(
-      Object.assign({}, defaultState, {
+      Object.assign({}, defaultState(), {
         knotSyncing: true,
         knotSynced: false,
         tapLogs: [],
@@ -136,7 +136,7 @@ describe('knots reducer', () => {
         type: knotActions.KNOT_SYNCED
       })
     ).toEqual(
-      Object.assign({}, defaultState, {
+      Object.assign({}, defaultState(), {
         knotSyncing: false,
         knotSynced: true
       })
@@ -149,7 +149,7 @@ describe('knots reducer', () => {
         type: knotActions.KNOT_DELETED
       })
     ).toEqual(
-      Object.assign({}, defaultState, {
+      Object.assign({}, defaultState(), {
         knotDeleted: true
       })
     );
@@ -161,7 +161,7 @@ describe('knots reducer', () => {
         type: knotActions.LOADING_KNOT
       })
     ).toEqual(
-      Object.assign({}, defaultState, {
+      Object.assign({}, defaultState(), {
         knotLoading: true
       })
     );
@@ -174,7 +174,7 @@ describe('knots reducer', () => {
         knotName: 'knotname'
       })
     ).toEqual(
-      Object.assign({}, defaultState, {
+      Object.assign({}, defaultState(), {
         knotLoading: false,
         knotLoaded: true,
         knotName: 'knotname'
@@ -187,6 +187,6 @@ describe('knots reducer', () => {
       knotReducer(undefined, {
         type: knotActions.RESET_STORE
       })
-    ).toEqual(Object.assign({}, defaultState));
+    ).toEqual(Object.assign({}, defaultState()));
   });
 });

--- a/test/util.js
+++ b/test/util.js
@@ -180,10 +180,10 @@ export const seedInvalidKnot = () =>
 
 export const seedTapCatalog = () =>
   new Promise((resolve, reject) => {
-    shell.mkdir('-p', path.resolve('tmp', 'knot', 'tap'));
+    shell.mkdir('-p', path.resolve('tmp', 'uuid', 'knot', 'tap'));
 
     fs.writeFile(
-      path.resolve('tmp', 'knot', 'tap', 'catalog.json'),
+      path.resolve('tmp', 'uuid', 'knot', 'tap', 'catalog.json'),
       JSON.stringify(sampleTapCatalog),
       (error) => {
         if (!error) {
@@ -219,10 +219,10 @@ export const seedTapCatalog = () =>
 
 export const seedTapConfig = () =>
   new Promise((resolve, reject) => {
-    shell.mkdir('-p', path.resolve('tmp', 'knot', 'tap'));
+    shell.mkdir('-p', path.resolve('tmp', 'configUUID', 'knot', 'tap'));
 
     fs.writeFile(
-      path.resolve('tmp', 'knot', 'tap', 'config.json'),
+      path.resolve('tmp', 'configUUID', 'knot', 'tap', 'config.json'),
       JSON.stringify(sampleTapConfig),
       (error) => {
         if (!error) {

--- a/test/util.js
+++ b/test/util.js
@@ -150,6 +150,34 @@ export const seedKnot = () =>
       .catch(reject);
   });
 
+export const seedTempKnot = () =>
+  new Promise((resolve, reject) => {
+    shell.mkdir('-p', path.resolve('tmp', 'tempUUID', 'knot', 'tap'));
+    shell.mkdir('-p', path.resolve('tmp', 'tempUUID', 'knot', 'target'));
+    const promises = [
+      writeFile(
+        path.resolve('tmp', 'tempUUID', 'knot', 'knot.json'),
+        JSON.stringify(sampleSavedKnot.knotJson)
+      ),
+      writeFile(
+        path.resolve('tmp', 'tempUUID', 'knot', 'tap', 'config.json'),
+        JSON.stringify(sampleSavedKnot.tapConfig)
+      ),
+      writeFile(
+        path.resolve('tmp', 'tempUUID', 'knot', 'tap', 'catalog.json'),
+        JSON.stringify(sampleSavedKnot.tapCatalog)
+      ),
+      writeFile(
+        path.resolve('tmp', 'tempUUID', 'knot', 'target', 'config.json'),
+        JSON.stringify(sampleSavedKnot.targetConfig)
+      )
+    ];
+
+    Promise.all(promises)
+      .then(resolve)
+      .catch(reject);
+  });
+
 export const seedInvalidKnot = () =>
   new Promise((resolve, reject) => {
     shell.mkdir('-p', path.resolve('knots', 'invalidSavedKnot', 'tap'));
@@ -157,7 +185,7 @@ export const seedInvalidKnot = () =>
     const promises = [
       writeFile(
         path.resolve('knots', 'invalidSavedKnot', 'knot.json'),
-        JSON.stringify(sampleSavedKnot.knotJson)
+        '{name: "invalidKnot}'
       ),
       writeFile(
         path.resolve('knots', 'invalidSavedKnot', 'tap', 'config.json'),


### PR DESCRIPTION
The UUID is generated by [shortid](https://github.com/dylang/shortid) whenever:

 * `Get Started` is clicked on the empty knots page
 * `New Knot` is clicked on the knots page
 * `Edit` is clicked on an individual knot.

The UUID is stored in the knots store from where all the other components access it.

A knot being created or edited resides in `/tmp/{uuid}/knot/` with the folder being deleted after the last step of the wizard (save).

The entire `tmp` folder is deleted on app startup (when the getKnots function is called)

Also: 

 * Full and partial syncs now only lead to the tap and target values in the saved `knot.json` being read without the full knot being copied.

 * Added some test cases.

 * Fixed a bug associated with knot names having trailing or leading white space.