### PR TITLE
Fix "Assignment to constant variable" error

### DIFF
--- a/app/backend/knots.js
+++ b/app/backend/knots.js
@@ -106,8 +106,12 @@ const sync = (req, mode) =>
       .then((knotObjectString) => {
         try {
           const knotObject = JSON.parse(knotObjectString);
-          const tapLogPath = path.resolve(pathToKnot, 'tap.log');
-          const targetLogPath = path.resolve(pathToKnot, 'target.log');
+          /* eslint-disable prefer-const */
+          // "Assignment to constant variable" error when const is used
+          // TODO: Investigate further
+          let tapLogPath = path.resolve(pathToKnot, 'tap.log');
+          let targetLogPath = path.resolve(pathToKnot, 'target.log');
+          /* eslint-disable prefer-const */
 
           addKnotAttribute(
             { field: ['lastRun'], value: new Date().toISOString() },


### PR DESCRIPTION
Main process code is uglified during the build process where the `Sync` function is converted to:

```
sync: (e, t) =>
  new Promise((n, i) => {
    const { knotName: o } = e.body,
      l = a.resolve(p(), o);
    d(a.resolve(l, "knot.json"))
      .then(o => {
        try {
          const u = JSON.parse(o),
            p = a.resolve(l, "tap.log"),
            d = a.resolve(l, "target.log");
          f(
            { field: ["lastRun"], value: new Date().toISOString() },
            a.resolve(l, "knot.json")
          )
            .then(() => {
              const o =
                  "partial" === t
                    ? b.runPartialSync(l, u.tap, u.target)
                    : b.runSync(l, u.tap, u.target),
                a = s(`set -o pipefail;${o}`, {
                  detached: !0,
                  shell: "/bin/bash"
                });
              (x = a),
                (e = e),
                (p = p),
                (d = d),
                r.watchFile(p, () => {
                  c("cat", [p], (t, n) => {
                    e.io.emit("tapLog", n.toString());
                  });
                }),
                r.watchFile(d, () => {
                  c("cat", [d], (t, n) => {
                    e.io.emit("targetLog", n.toString());
                  });
                }),
                a.on("exit", e => {
                  e > 0 ? i(new Error("Sync failed")) : n();
                }),
                a.on("error", () => {
                  i(new Error("Sync failed"));
                });
            })
            .catch(e => {
              i(e);
            });
        } catch (e) {
          i(e);
        }
      })
      .catch(i);
  }),
```

There is an attempt to reassign the consts `p` and `d` to themselves which leads to an `Assignment to constant variable` error in the packaged app.

Changing these two variables' declaration from `const` to `let` resolves the error.