### PR TITLE
Ci test fix

### DIFF
--- a/app/backend/util.js
+++ b/app/backend/util.js
@@ -59,7 +59,13 @@ const createTemporaryKnotFolder = (uuid) => {
   );
 };
 
-const getKnotsFolder = () => path.resolve(getApplicationFolder(), 'knots');
+const getKnotsFolder = () => {
+  if (process.env.NODE_ENV === 'test') {
+    return path.resolve(getApplicationFolder(), 'knotsTestFolder');
+  }
+  return path.resolve(getApplicationFolder(), 'knots');
+};
+
 const getTemporaryKnotFolder = (uuid) =>
   path.resolve(getApplicationFolder(), 'tmp', uuid, 'knot');
 

--- a/test/backend/knots.spec.js
+++ b/test/backend/knots.spec.js
@@ -58,9 +58,9 @@ describe('knots functions', () => {
 
     it('should reject promise when there is an invalid knot', (done) => {
       process.env.NODE_ENV = 'test';
-      shell.mkdir('-p', path.resolve('knots', 'sample 3'));
+      shell.mkdir('-p', path.resolve('knotsTestFolder', 'sample 3'));
       fs.writeFile(
-        path.resolve('knots', 'sample 3', 'knot.json'),
+        path.resolve('knotsTestFolder', 'sample 3', 'knot.json'),
         invalidKnotString,
         (err) => {
           if (!err) {
@@ -167,7 +167,7 @@ describe('knots functions', () => {
   });
 
   describe('load values', () => {
-    beforeEach((done) => {
+    beforeAll((done) => {
       seedKnot()
         .then(() => {
           seedInvalidKnot()
@@ -185,7 +185,7 @@ describe('knots functions', () => {
         });
     });
 
-    afterEach(() => {
+    afterAll(() => {
       cleanfs();
     });
 
@@ -249,7 +249,7 @@ describe('knots functions', () => {
       saveKnot('knotName', 'tempUUID')
         .then(() => {
           fs.access(
-            path.resolve('knots', 'knotName'),
+            path.resolve('knotsTestFolder', 'knotName'),
             fs.constants.F_OK,
             (err) => {
               expect(err).toBeNull();
@@ -267,7 +267,7 @@ describe('knots functions', () => {
       saveKnot('knotName', 'tempUUID', 'savedKnot')
         .then(() => {
           fs.access(
-            path.resolve('knots', 'savedKnot'),
+            path.resolve('knotsTestFolder', 'savedKnot'),
             fs.constants.F_OK,
             (err) => {
               expect(err).toBeDefined();
@@ -302,7 +302,7 @@ describe('knots functions', () => {
       deleteKnot('savedKnot')
         .then(() => {
           fs.readFile(
-            path.resolve('knots', 'savedKnot', 'knot.json'),
+            path.resolve('knotsTestFolder', 'savedKnot', 'knot.json'),
             (err) => {
               if (!err) {
                 expect(true).toBe(false);

--- a/test/backend/knots.spec.js
+++ b/test/backend/knots.spec.js
@@ -167,7 +167,7 @@ describe('knots functions', () => {
   });
 
   describe('load values', () => {
-    beforeAll((done) => {
+    beforeEach((done) => {
       seedKnot()
         .then(() => {
           seedInvalidKnot()
@@ -185,7 +185,7 @@ describe('knots functions', () => {
         });
     });
 
-    afterAll(() => {
+    afterEach(() => {
       cleanfs();
     });
 

--- a/test/backend/util.spec.js
+++ b/test/backend/util.spec.js
@@ -50,7 +50,7 @@ describe('util functions', () => {
     it('should return folder based on repo when not in production', () => {
       process.env.NODE_ENV = 'test';
       const actual = getKnotsFolder();
-      const expected = path.resolve(__dirname, '../..', 'knots');
+      const expected = path.resolve(__dirname, '../..', 'knotsTestFolder');
 
       expect(actual).toEqual(expected);
     });

--- a/test/backend/util.spec.js
+++ b/test/backend/util.spec.js
@@ -234,7 +234,7 @@ describe('util functions', () => {
   });
 
   describe('addKnotAttribute', () => {
-    beforeAll((done) => {
+    beforeEach((done) => {
       shell.mkdir('-p', path.resolve('tmp', 'knotUUID', 'knot'));
       fs.writeFile(
         path.resolve('tmp', 'knotUUID', 'knot', 'knot.json'),
@@ -250,7 +250,7 @@ describe('util functions', () => {
       );
     });
 
-    afterAll(() => {
+    afterEach(() => {
       shell.rm('-f', path.resolve('sampleKnot.json'));
       shell.rm('-f', path.resolve('broken.json'));
       cleanfs();

--- a/test/util.js
+++ b/test/util.js
@@ -82,19 +82,19 @@ export const seedKnots = () =>
   new Promise((resolve, reject) => {
     const sampleKnotNames = ['sample 1', 'sample 2'];
 
-    shell.mkdir('-p', path.resolve('knots'));
+    shell.mkdir('-p', path.resolve('knotsTestFolder'));
 
     sampleKnotNames.forEach((knot) => {
-      shell.mkdir('-p', path.resolve('knots', knot));
+      shell.mkdir('-p', path.resolve('knotsTestFolder', knot));
     });
 
     fs.writeFile(
-      path.resolve('knots', 'sample 1', 'knot.json'),
+      path.resolve('knotsTestFolder', 'sample 1', 'knot.json'),
       JSON.stringify(sampleKnotJsons[0]),
       (error) => {
         if (!error) {
           fs.writeFile(
-            path.resolve('knots', 'sample 2', 'knot.json'),
+            path.resolve('knotsTestFolder', 'sample 2', 'knot.json'),
             JSON.stringify(sampleKnotJsons[1]),
             (err) => {
               if (!err) {
@@ -124,23 +124,23 @@ const writeFile = (filePath, content) =>
 
 export const seedKnot = () =>
   new Promise((resolve, reject) => {
-    shell.mkdir('-p', path.resolve('knots', 'savedKnot', 'tap'));
-    shell.mkdir('-p', path.resolve('knots', 'savedKnot', 'target'));
+    shell.mkdir('-p', path.resolve('knotsTestFolder', 'savedKnot', 'tap'));
+    shell.mkdir('-p', path.resolve('knotsTestFolder', 'savedKnot', 'target'));
     const promises = [
       writeFile(
-        path.resolve('knots', 'savedKnot', 'knot.json'),
+        path.resolve('knotsTestFolder', 'savedKnot', 'knot.json'),
         JSON.stringify(sampleSavedKnot.knotJson)
       ),
       writeFile(
-        path.resolve('knots', 'savedKnot', 'tap', 'config.json'),
+        path.resolve('knotsTestFolder', 'savedKnot', 'tap', 'config.json'),
         JSON.stringify(sampleSavedKnot.tapConfig)
       ),
       writeFile(
-        path.resolve('knots', 'savedKnot', 'tap', 'catalog.json'),
+        path.resolve('knotsTestFolder', 'savedKnot', 'tap', 'catalog.json'),
         JSON.stringify(sampleSavedKnot.tapCatalog)
       ),
       writeFile(
-        path.resolve('knots', 'savedKnot', 'target', 'config.json'),
+        path.resolve('knotsTestFolder', 'savedKnot', 'target', 'config.json'),
         JSON.stringify(sampleSavedKnot.targetConfig)
       )
     ];
@@ -180,23 +180,44 @@ export const seedTempKnot = () =>
 
 export const seedInvalidKnot = () =>
   new Promise((resolve, reject) => {
-    shell.mkdir('-p', path.resolve('knots', 'invalidSavedKnot', 'tap'));
-    shell.mkdir('-p', path.resolve('knots', 'invalidSavedKnot', 'target'));
+    shell.mkdir(
+      '-p',
+      path.resolve('knotsTestFolder', 'invalidSavedKnot', 'tap')
+    );
+    shell.mkdir(
+      '-p',
+      path.resolve('knotsTestFolder', 'invalidSavedKnot', 'target')
+    );
     const promises = [
       writeFile(
-        path.resolve('knots', 'invalidSavedKnot', 'knot.json'),
+        path.resolve('knotsTestFolder', 'invalidSavedKnot', 'knot.json'),
         '{name: "invalidKnot}'
       ),
       writeFile(
-        path.resolve('knots', 'invalidSavedKnot', 'tap', 'config.json'),
+        path.resolve(
+          'knotsTestFolder',
+          'invalidSavedKnot',
+          'tap',
+          'config.json'
+        ),
         JSON.stringify(sampleSavedKnot.tapConfig)
       ),
       writeFile(
-        path.resolve('knots', 'invalidSavedKnot', 'tap', 'catalog.json'),
+        path.resolve(
+          'knotsTestFolder',
+          'invalidSavedKnot',
+          'tap',
+          'catalog.json'
+        ),
         `${JSON.stringify(sampleSavedKnot.tapCatalog)}}`
       ),
       writeFile(
-        path.resolve('knots', 'invalidSavedKnot', 'target', 'config.json'),
+        path.resolve(
+          'knotsTestFolder',
+          'invalidSavedKnot',
+          'target',
+          'config.json'
+        ),
         JSON.stringify(sampleSavedKnot.targetConfig)
       )
     ];
@@ -215,15 +236,26 @@ export const seedTapCatalog = () =>
       JSON.stringify(sampleTapCatalog),
       (error) => {
         if (!error) {
-          shell.mkdir('-p', path.resolve('knots', 'savedKnot', 'tap'));
+          shell.mkdir(
+            '-p',
+            path.resolve('knotsTestFolder', 'savedKnot', 'tap')
+          );
           fs.writeFile(
-            path.resolve('knots', 'savedKnot', 'tap', 'catalog.json'),
+            path.resolve('knotsTestFolder', 'savedKnot', 'tap', 'catalog.json'),
             JSON.stringify(savedSampleTapCatalog),
             (err) => {
               if (!err) {
-                shell.mkdir('-p', path.resolve('knots', 'invalidKnot', 'tap'));
+                shell.mkdir(
+                  '-p',
+                  path.resolve('knotsTestFolder', 'invalidKnot', 'tap')
+                );
                 fs.writeFile(
-                  path.resolve('knots', 'invalidKnot', 'tap', 'catalog.json'),
+                  path.resolve(
+                    'knotsTestFolder',
+                    'invalidKnot',
+                    'tap',
+                    'catalog.json'
+                  ),
                   'invalid json',
                   (er) => {
                     if (!er) {
@@ -263,7 +295,7 @@ export const seedTapConfig = () =>
   });
 
 export const cleanfs = () => {
-  shell.rm('-rf', path.resolve('knots'));
+  shell.rm('-rf', path.resolve('knotsTestFolder'));
   shell.rm('-rf', path.resolve('tmp'));
   shell.rm('-rf', path.resolve(os.homedir(), '.knots', 'tmp'));
 };


### PR DESCRIPTION
Initially, for test cases, we were saving a knot fixture inside the `knots` folder which also houses valid saved knots from the wizard run. So, when we finish running test and we remove all test related state builds (by removing the `knots` folder altogether) we also remove valid saved knots.

Fix was to separate the directory we are saving knots related to testing from the valid saved knots.

This change also seems to have fixed the test failure on CI due to possible state leaks.