### PR TITLE
Updated the Makefile to include Python targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,11 @@ main.js
 main.js.map
 
 .env
-.idea
 npm-debug.log.*
+
+# IDE files
+*.iml
+.idea
 
 # Knot temp files
 tmp

--- a/app/backend/util.js
+++ b/app/backend/util.js
@@ -122,7 +122,7 @@ const addKnotAttribute = (content, knotPath, uuid) =>
 const createMakeFileCommands = (knot) => {
   const tapVersion = knot.tap.image.split(':')[1];
   const targetVersion = knot.target.image.split(':')[1];
-  const { usesCatalogArg = true } = knot.specImplementation || {};
+  const { usesCatalogArg = true } = knot.tap.specImplementation || {};
   /* eslint-disable no-template-curly-in-string */
   return `SHELL=/bin/bash -o pipefail\n\nTAP=${
     knot.tap.name

--- a/app/backend/util.js
+++ b/app/backend/util.js
@@ -120,32 +120,53 @@ const addKnotAttribute = (content, knotPath, uuid) =>
   });
 
 const createMakeFileCommands = (knot) => {
-  const { tap } = knot;
-  const { usesCatalogArg = true } = tap.specImplementation || {};
+  const tapVersion = knot.tap.image.split(':')[1];
+  const targetVersion = knot.target.image.split(':')[1];
+  const { usesCatalogArg = true } = knot.specImplementation || {};
   /* eslint-disable no-template-curly-in-string */
-  return `SHELL=/bin/bash -o pipefail\n\nfullSync:${
+  return `SHELL=/bin/bash -o pipefail\n\nTAP=${
+    knot.tap.name
+  }\nTAP_VERSION=${tapVersion}\nTAP_IMAGE=${knot.tap.image}\nTARGET=${
+    knot.target.name
+  }\nTARGET_VERSION=${targetVersion}\nTARGET_IMAGE=${knot.target.image}\n${
     os.EOL
-  }\t-\tdocker run -v "$(CURDIR)/tap:/app/tap/data" --interactive ${
-    knot.tap.image
-  } ${knot.tap.name} -c tap/data/config.json ${
+  }full-sync:${
+    os.EOL
+  }\t-\tdocker run -v "$(CURDIR)/tap:/app/tap/data" --interactive $(TAP_IMAGE) $(TAP) -c tap/data/config.json ${
     usesCatalogArg ? '--catalog' : '--properties'
-  } tap/data/catalog.json | docker run -v "$(CURDIR)/target:/app/target/data" --interactive ${
-    knot.target.image
-  } ${knot.target.name} -c target/data/config.json > ./tap/state.json${
+  } tap/data/catalog.json | docker run -v "$(CURDIR)/target:/app/target/data" --interactive $(TARGET_IMAGE) $(TARGET) -c target/data/config.json > tap/state.json\n${
     os.EOL
   }sync:${
     os.EOL
-  }\tif [ ! -f ./tap/latest-state.json ]; then touch ./tap/latest-state.json; fi${
+  }\tif [ ! -f tap/latest-state.json ]; then touch tap/latest-state.json; fi${
     os.EOL
-  }\ttail -1 "$(CURDIR)/tap/state.json" > "$(CURDIR)/tap/latest-state.json"; \\${
+  }\ttail -1 "tap/state.json" > "tap/latest-state.json"; \\${
     os.EOL
-  }\tdocker run -v "$(CURDIR)/tap:/app/tap/data" --interactive ${
-    knot.tap.image
-  } ${knot.tap.name} -c tap/data/config.json ${
+  }\tdocker run -v "$(CURDIR)/tap:/app/tap/data" --interactive $(TAP_IMAGE) $(TAP) -c tap/data/config.json ${
     usesCatalogArg ? '--catalog' : '--properties'
-  } tap/data/catalog.json --state tap/data/latest-state.json | docker run -v "$(CURDIR)/target:/app/target/data" --interactive ${
-    knot.target.image
-  } ${knot.target.name} -c target/data/config.json > ./tap/state.json`;
+  } tap/data/catalog.json --state tap/data/latest-state.json | docker run -v "$(CURDIR)/target:/app/target/data" --interactive $(TARGET_IMAGE) $(TARGET) -c target/data/config.json > tap/state.json\n${
+    os.EOL
+  }setup-py-envs:${os.EOL}\tpython3 -m venv venvs/tap${
+    os.EOL
+  }\tpython3 -m venv venvs/target${
+    os.EOL
+  }\tvenvs/tap/bin/pip install $(TAP)==$(TAP_VERSION)${
+    os.EOL
+  }\tvenvs/target/bin/pip install $(TARGET)==$(TARGET_VERSION)\n${
+    os.EOL
+  }py-full-sync:${os.EOL}\tvenvs/tap/bin/$(TAP) -c tap/config.json ${
+    usesCatalogArg ? '--catalog' : '--properties'
+  } tap/catalog.json | venvs/target/bin/$(TARGET) -c target/config.json > tap/state.json\n${
+    os.EOL
+  }py-sync:${
+    os.EOL
+  }\tif [ ! -f tap/latest-state.json ]; then touch tap/latest-state.json; fi${
+    os.EOL
+  }\ttail -1 "tap/state.json" > "tap/latest-state.json"; \\${
+    os.EOL
+  }\tvenvs/tap/bin/$(TAP) -c tap/config.json ${
+    usesCatalogArg ? '--catalog' : '--properties'
+  } tap/catalog.json --state tap/latest-state.json | venvs/target/bin/$(TARGET) -c target/config.json > tap/state.json`;
 };
 /* eslint-disable no-template-curly-in-string */
 

--- a/test/backend/util.spec.js
+++ b/test/backend/util.spec.js
@@ -317,17 +317,39 @@ describe('util functions', () => {
   describe('createMakefileCommands', () => {
     it('should create valid makefile commands for taps with catalog command', () => {
       /* eslint-disable no-tabs */
-      const expected = `SHELL=/bin/bash -o pipefail\n\nfullSync:${
+      const expected = `SHELL=/bin/bash -o pipefail\n\nTAP=tap-redshift\nTAP_VERSION=1.0.0b8\nTAP_IMAGE=dataworld/tap-redshift:1.0.0b8\nTARGET=target-datadotworld\nTARGET_VERSION=1.0.1\nTARGET_IMAGE=dataworld/target-datadotworld:1.0.1\n${
         os.EOL
-      }\t-\tdocker run -v "$(CURDIR)/tap:/app/tap/data" --interactive ${'dataworld/tap-redshift:1.0.0b8'} ${'tap-redshift'} -c tap/data/config.json --catalog tap/data/catalog.json | docker run -v "$(CURDIR)/target:/app/target/data" --interactive ${'dataworld/target-datadotworld:1.0.1'} ${'target-datadotworld'} -c target/data/config.json > ./tap/state.json${
+      }full-sync:${
+        os.EOL
+      }\t-\tdocker run -v "$(CURDIR)/tap:/app/tap/data" --interactive $(TAP_IMAGE) $(TAP) -c tap/data/config.json --catalog tap/data/catalog.json | docker run -v "$(CURDIR)/target:/app/target/data" --interactive $(TARGET_IMAGE) $(TARGET) -c target/data/config.json > tap/state.json\n${
         os.EOL
       }sync:${
         os.EOL
-      }\tif [ ! -f ./tap/latest-state.json ]; then touch ./tap/latest-state.json; fi${
+      }\tif [ ! -f tap/latest-state.json ]; then touch tap/latest-state.json; fi${
         os.EOL
-      }\ttail -1 "$(CURDIR)/tap/state.json" > "$(CURDIR)/tap/latest-state.json"; \\${
+      }\ttail -1 "tap/state.json" > "tap/latest-state.json"; \\${
         os.EOL
-      }\tdocker run -v "$(CURDIR)/tap:/app/tap/data" --interactive ${'dataworld/tap-redshift:1.0.0b8'} ${'tap-redshift'} -c tap/data/config.json --catalog tap/data/catalog.json --state tap/data/latest-state.json | docker run -v "$(CURDIR)/target:/app/target/data" --interactive ${'dataworld/target-datadotworld:1.0.1'} ${'target-datadotworld'} -c target/data/config.json > ./tap/state.json`;
+      }\tdocker run -v "$(CURDIR)/tap:/app/tap/data" --interactive $(TAP_IMAGE) $(TAP) -c tap/data/config.json --catalog tap/data/catalog.json --state tap/data/latest-state.json | docker run -v "$(CURDIR)/target:/app/target/data" --interactive $(TARGET_IMAGE) $(TARGET) -c target/data/config.json > tap/state.json\n${
+        os.EOL
+      }setup-py-envs:${os.EOL}\tpython3 -m venv venvs/tap${
+        os.EOL
+      }\tpython3 -m venv venvs/target${
+        os.EOL
+      }\tvenvs/tap/bin/pip install $(TAP)==$(TAP_VERSION)${
+        os.EOL
+      }\tvenvs/target/bin/pip install $(TARGET)==$(TARGET_VERSION)\n${
+        os.EOL
+      }py-full-sync:${
+        os.EOL
+      }\tvenvs/tap/bin/$(TAP) -c tap/config.json --catalog tap/catalog.json | venvs/target/bin/$(TARGET) -c target/config.json > tap/state.json\n${
+        os.EOL
+      }py-sync:${
+        os.EOL
+      }\tif [ ! -f tap/latest-state.json ]; then touch tap/latest-state.json; fi${
+        os.EOL
+      }\ttail -1 "tap/state.json" > "tap/latest-state.json"; \\${
+        os.EOL
+      }\tvenvs/tap/bin/$(TAP) -c tap/config.json --catalog tap/catalog.json --state tap/latest-state.json | venvs/target/bin/$(TARGET) -c target/config.json > tap/state.json`;
 
       const actual = createMakeFileCommands({
         tap: {
@@ -346,17 +368,39 @@ describe('util functions', () => {
 
     it('should create valid makefile commands for taps with properties command', () => {
       /* eslint-disable no-tabs */
-      const expected = `SHELL=/bin/bash -o pipefail\n\nfullSync:${
+      const expected = `SHELL=/bin/bash -o pipefail\n\nTAP=tap-facebook\nTAP_VERSION=1.5.1\nTAP_IMAGE=dataworld/tap-facebook:1.5.1\nTARGET=target-datadotworld\nTARGET_VERSION=1.0.1\nTARGET_IMAGE=dataworld/target-datadotworld:1.0.1\n${
         os.EOL
-      }\t-\tdocker run -v "$(CURDIR)/tap:/app/tap/data" --interactive ${'dataworld/tap-facebook:1.5.1'} ${'tap-facebook'} -c tap/data/config.json --properties tap/data/catalog.json | docker run -v "$(CURDIR)/target:/app/target/data" --interactive ${'dataworld/target-datadotworld:1.0.1'} ${'target-datadotworld'} -c target/data/config.json > ./tap/state.json${
+      }full-sync:${
+        os.EOL
+      }\t-\tdocker run -v "$(CURDIR)/tap:/app/tap/data" --interactive $(TAP_IMAGE) $(TAP) -c tap/data/config.json --catalog tap/data/catalog.json | docker run -v "$(CURDIR)/target:/app/target/data" --interactive $(TARGET_IMAGE) $(TARGET) -c target/data/config.json > tap/state.json\n${
         os.EOL
       }sync:${
         os.EOL
-      }\tif [ ! -f ./tap/latest-state.json ]; then touch ./tap/latest-state.json; fi${
+      }\tif [ ! -f tap/latest-state.json ]; then touch tap/latest-state.json; fi${
         os.EOL
-      }\ttail -1 "$(CURDIR)/tap/state.json" > "$(CURDIR)/tap/latest-state.json"; \\${
+      }\ttail -1 "tap/state.json" > "tap/latest-state.json"; \\${
         os.EOL
-      }\tdocker run -v "$(CURDIR)/tap:/app/tap/data" --interactive ${'dataworld/tap-facebook:1.5.1'} ${'tap-facebook'} -c tap/data/config.json --properties tap/data/catalog.json --state tap/data/latest-state.json | docker run -v "$(CURDIR)/target:/app/target/data" --interactive ${'dataworld/target-datadotworld:1.0.1'} ${'target-datadotworld'} -c target/data/config.json > ./tap/state.json`;
+      }\tdocker run -v "$(CURDIR)/tap:/app/tap/data" --interactive $(TAP_IMAGE) $(TAP) -c tap/data/config.json --catalog tap/data/catalog.json --state tap/data/latest-state.json | docker run -v "$(CURDIR)/target:/app/target/data" --interactive $(TARGET_IMAGE) $(TARGET) -c target/data/config.json > tap/state.json\n${
+        os.EOL
+      }setup-py-envs:${os.EOL}\tpython3 -m venv venvs/tap${
+        os.EOL
+      }\tpython3 -m venv venvs/target${
+        os.EOL
+      }\tvenvs/tap/bin/pip install $(TAP)==$(TAP_VERSION)${
+        os.EOL
+      }\tvenvs/target/bin/pip install $(TARGET)==$(TARGET_VERSION)\n${
+        os.EOL
+      }py-full-sync:${
+        os.EOL
+      }\tvenvs/tap/bin/$(TAP) -c tap/config.json --catalog tap/catalog.json | venvs/target/bin/$(TARGET) -c target/config.json > tap/state.json\n${
+        os.EOL
+      }py-sync:${
+        os.EOL
+      }\tif [ ! -f tap/latest-state.json ]; then touch tap/latest-state.json; fi${
+        os.EOL
+      }\ttail -1 "tap/state.json" > "tap/latest-state.json"; \\${
+        os.EOL
+      }\tvenvs/tap/bin/$(TAP) -c tap/config.json --catalog tap/catalog.json --state tap/latest-state.json | venvs/target/bin/$(TARGET) -c target/config.json > tap/state.json`;
 
       const actual = createMakeFileCommands({
         tap: {

--- a/test/backend/util.spec.js
+++ b/test/backend/util.spec.js
@@ -372,7 +372,7 @@ describe('util functions', () => {
         os.EOL
       }full-sync:${
         os.EOL
-      }\t-\tdocker run -v "$(CURDIR)/tap:/app/tap/data" --interactive $(TAP_IMAGE) $(TAP) -c tap/data/config.json --catalog tap/data/catalog.json | docker run -v "$(CURDIR)/target:/app/target/data" --interactive $(TARGET_IMAGE) $(TARGET) -c target/data/config.json > tap/state.json\n${
+      }\t-\tdocker run -v "$(CURDIR)/tap:/app/tap/data" --interactive $(TAP_IMAGE) $(TAP) -c tap/data/config.json --properties tap/data/catalog.json | docker run -v "$(CURDIR)/target:/app/target/data" --interactive $(TARGET_IMAGE) $(TARGET) -c target/data/config.json > tap/state.json\n${
         os.EOL
       }sync:${
         os.EOL
@@ -380,7 +380,7 @@ describe('util functions', () => {
         os.EOL
       }\ttail -1 "tap/state.json" > "tap/latest-state.json"; \\${
         os.EOL
-      }\tdocker run -v "$(CURDIR)/tap:/app/tap/data" --interactive $(TAP_IMAGE) $(TAP) -c tap/data/config.json --catalog tap/data/catalog.json --state tap/data/latest-state.json | docker run -v "$(CURDIR)/target:/app/target/data" --interactive $(TARGET_IMAGE) $(TARGET) -c target/data/config.json > tap/state.json\n${
+      }\tdocker run -v "$(CURDIR)/tap:/app/tap/data" --interactive $(TAP_IMAGE) $(TAP) -c tap/data/config.json --properties tap/data/catalog.json --state tap/data/latest-state.json | docker run -v "$(CURDIR)/target:/app/target/data" --interactive $(TARGET_IMAGE) $(TARGET) -c target/data/config.json > tap/state.json\n${
         os.EOL
       }setup-py-envs:${os.EOL}\tpython3 -m venv venvs/tap${
         os.EOL
@@ -392,7 +392,7 @@ describe('util functions', () => {
         os.EOL
       }py-full-sync:${
         os.EOL
-      }\tvenvs/tap/bin/$(TAP) -c tap/config.json --catalog tap/catalog.json | venvs/target/bin/$(TARGET) -c target/config.json > tap/state.json\n${
+      }\tvenvs/tap/bin/$(TAP) -c tap/config.json --properties tap/catalog.json | venvs/target/bin/$(TARGET) -c target/config.json > tap/state.json\n${
         os.EOL
       }py-sync:${
         os.EOL
@@ -400,7 +400,7 @@ describe('util functions', () => {
         os.EOL
       }\ttail -1 "tap/state.json" > "tap/latest-state.json"; \\${
         os.EOL
-      }\tvenvs/tap/bin/$(TAP) -c tap/config.json --catalog tap/catalog.json --state tap/latest-state.json | venvs/target/bin/$(TARGET) -c target/config.json > tap/state.json`;
+      }\tvenvs/tap/bin/$(TAP) -c tap/config.json --properties tap/catalog.json --state tap/latest-state.json | venvs/target/bin/$(TARGET) -c target/config.json > tap/state.json`;
 
       const actual = createMakeFileCommands({
         tap: {


### PR DESCRIPTION
Docker is fantastic but it's difficult to deal with in cloud environments due to the complexities of nested virtualization. The modified Makefile in here includes targets that make use of Python virtual environments, which are vastly easier to work with for cloud-related use cases.

The new Makefile looks as such:
```
SHELL=/bin/bash -o pipefail

TAP=tap-postgres
TAP_VERSION=0.0.16
TAP_IMAGE=dataworld/tap-postgres:0.0.16
TARGET=target-datadotworld
TARGET_VERSION=1.0.1
TARGET_IMAGE=dataworld/target-datadotworld:1.0.1

full-sync:
	-	docker run -v "$(CURDIR)/tap:/app/tap/data" --interactive $(TAP_IMAGE) $(TAP) -c tap/data/config.json --catalog tap/data/catalog.json | docker run -v "$(CURDIR)/target:/app/target/data" --interactive $(TARGET_IMAGE) $(TARGET) -c target/data/config.json > tap/state.json

sync:
	if [ ! -f tap/latest-state.json ]; then touch tap/latest-state.json; fi
	tail -1 "tap/state.json" > "tap/latest-state.json"; \
	docker run -v "$(CURDIR)/tap:/app/tap/data" --interactive $(TAP_IMAGE) $(TAP) -c tap/data/config.json --catalog tap/data/catalog.json --state tap/data/latest-state.json | docker run -v "$(CURDIR)/target:/app/target/data" --interactive $(TARGET_IMAGE) $(TARGET) -c target/data/config.json > tap/state.json

setup-py-envs:
	python3 -m venv venvs/tap
	python3 -m venv venvs/target
	venvs/tap/bin/pip install $(TAP)==$(TAP_VERSION)
	venvs/target/bin/pip install $(TARGET)==$(TARGET_VERSION)

py-full-sync:
	venvs/tap/bin/$(TAP) -c tap/config.json --catalog tap/catalog.json | venvs/target/bin/$(TARGET) -c target/config.json > tap/state.json

py-sync:
	if [ ! -f tap/latest-state.json ]; then touch tap/latest-state.json; fi
	tail -1 "tap/state.json" > "tap/latest-state.json"; \
	venvs/tap/bin/$(TAP) -c tap/config.json --catalog tap/catalog.json --state tap/latest-state.json | venvs/target/bin/$(TARGET) -c target/config.json > tap/state.json
```