### PR TITLE
Fix failing discovery command on Mac

### DIFF
--- a/app/backend/constants.js
+++ b/app/backend/constants.js
@@ -115,7 +115,7 @@ const commands = {
       tap.name
     }/data" ${dockerParameters} ${tap.image} ${tap.name} -c ${
       tap.name
-    }/data/config.json -d`;
+    }/data/config.json -d > "${path.resolve(folderPath)}/tap/catalog.json"`;
   },
   runSync: (folderPath, tap, target) => {
     const { usesCatalogArg = true, dockerParameters = '' } =

--- a/app/backend/taps.js
+++ b/app/backend/taps.js
@@ -21,7 +21,6 @@
 
 const path = require('path');
 const { exec } = require('child_process');
-const fs = require('fs');
 const shell = require('shelljs');
 
 const {
@@ -80,10 +79,6 @@ const getSchema = (req) =>
 
     shell.rm('-rf', path.resolve(knotPath, 'tap', 'catalog.json'));
     shell.mkdir('-p', path.resolve(knotPath, 'tap'));
-    const stdoutStream = fs.createWriteStream(
-      path.resolve(knotPath, 'tap', 'catalog.json'),
-      { flags: 'a' }
-    );
 
     const discoveryCommand = commands.runDiscovery(knotPath, req.body.tap);
 
@@ -100,8 +95,6 @@ const getSchema = (req) =>
         req.io.emit('schemaLog', data.toString());
       }
     });
-
-    runDiscovery.stdout.pipe(stdoutStream);
 
     runDiscovery.on('exit', (code) => {
       if (code > 0) {

--- a/test/backend/commands.spec.js
+++ b/test/backend/commands.spec.js
@@ -7,7 +7,9 @@ describe('commands', () => {
   it('returns the correct discovery command (without docker parameters)', () => {
     const expected = `docker run -v "${path.resolve(
       'applicationFolder'
-    )}/tap:/app/tap-redshift/data"  dataworld/tap-redshift:1.0.0b8 tap-redshift -c tap-redshift/data/config.json -d`;
+    )}/tap:/app/tap-redshift/data"  dataworld/tap-redshift:1.0.0b8 tap-redshift -c tap-redshift/data/config.json -d > "${path.resolve(
+      'applicationFolder'
+    )}/tap/catalog.json"`;
 
     const actual = commands.runDiscovery('applicationFolder', {
       name: 'tap-redshift',
@@ -23,7 +25,9 @@ describe('commands', () => {
   it('returns the correct discovery command (with docker parameters)', () => {
     const expected = `docker run -v "${path.resolve(
       'applicationFolder'
-    )}/tap:/app/tap-s3-csv/data" -v ${homePath}/.aws:/root/.aws dataworld/tap-s3-csv:0.0.3 tap-s3-csv -c tap-s3-csv/data/config.json -d`;
+    )}/tap:/app/tap-s3-csv/data" -v ${homePath}/.aws:/root/.aws dataworld/tap-s3-csv:0.0.3 tap-s3-csv -c tap-s3-csv/data/config.json -d > "${path.resolve(
+      'applicationFolder'
+    )}/tap/catalog.json"`;
 
     const actual = commands.runDiscovery('applicationFolder', {
       name: 'tap-s3-csv',


### PR DESCRIPTION
*Problem*

Piping of a command's output to a file using `fs.createWriteStream` fails to complete successfully on MacOS, this leads to an `unexpected end of JSON` error when we attempt to read the written `catalog.json` file.

*Fix*

Redirect the discovery command's output directly to `catalog.json` when running the discovery command with `exec`